### PR TITLE
changing python version requirements to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dreams_core"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="tentabs", email="tentabs00@gmail.com" },
 ]
 description = "brought to you by the dreamslabs discord community"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
   "requests>=2.25.1",
   "pandas>=1.2.0",


### PR DESCRIPTION
this is because google colab uses 3.10 and requires extensive alterations to upgrade the notebook's version of python